### PR TITLE
Add reference to bson library to permit insertion examples.

### DIFF
--- a/creating/creating-mongodb-documents-with-go.md
+++ b/creating/creating-mongodb-documents-with-go.md
@@ -68,6 +68,7 @@ import (
 	"context"
 	"log"
 	"time"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )


### PR DESCRIPTION
Second insertion example references a bson field which will require reference/import to the bson library.